### PR TITLE
Fix heading warnings

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -458,15 +458,19 @@ class Simple_FB_Instant_Articles {
 
 		foreach ( $headings as $heading_tag ) {
 
-			foreach ( $dom->getElementsByTagName( $heading_tag ) as $node ) {
+			$headings = $dom->getElementsByTagName( $heading_tag );
 
-				$h2 = $dom->createElement( 'h2' );
+			while ( $headings->length ) {
+
+				$node = $headings->item( $i );
+				$h2   = $dom->createElement( 'h2' );
 
 				while ( $node->childNodes->length > 0 ) {
 					$h2->appendChild( $node->childNodes->item( 0 ) );
 				}
 
 				$node->parentNode->replaceChild( $h2, $node );
+
 			}
 		}
 	}

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -431,29 +431,28 @@ class Simple_FB_Instant_Articles {
 	 *
 	 * Replace with h2s.
 	 *
-	 * @param  \DOMDocument &$dom   Dom.
-	 * @param  \DOMXPath    &$xpath Xpath.
+	 * @param  \DOMDocument &$dom   DOM object generated for post content.
+	 * @param  \DOMXPath    &$xpath XPATH object generated for post content.
 	 *
 	 * @return void
 	 */
 	public function fix_headings( \DOMDocument &$dom, \DOMXPath &$xpath ) {
 
-		$headings = array( 'h3', 'h4', 'h5' );
+		$headings = array( 'h3', 'h4', 'h5', 'h6' );
 
 		foreach ( $headings as $heading_tag ) {
+
 			foreach ( $dom->getElementsByTagName( $heading_tag ) as $node ) {
 
 				$h2 = $dom->createElement( 'h2' );
 
 				while ( $node->childNodes->length > 0 ) {
-					$h2->appendChild( $node->childNodes->item(0) );
+					$h2->appendChild( $node->childNodes->item( 0 ) );
 				}
 
 				$node->parentNode->replaceChild( $h2, $node );
-
 			}
 		}
-
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -187,6 +187,8 @@ class Simple_FB_Instant_Articles {
 		// Render post content into FB IA format - using DOM object.
 		add_action( 'simple_fb_reformat_post_content', array( $this, 'render_pull_quotes' ), 10, 2 );
 		add_action( 'simple_fb_reformat_post_content', array( $this, 'render_images' ), 10, 2 );
+		add_action( 'simple_fb_reformat_post_content', array( $this, 'fix_headings' ), 10, 2 );
+
 	}
 
 	public function rss_permalink( $link ) {
@@ -422,6 +424,36 @@ class Simple_FB_Instant_Articles {
 
 			$figure->appendChild( $node );
 		}
+	}
+
+	/**
+	 * Facebook throws a warning for all headings below h2.
+	 *
+	 * Replace with h2s.
+	 *
+	 * @param  \DOMDocument &$dom   Dom.
+	 * @param  \DOMXPath    &$xpath Xpath.
+	 *
+	 * @return void
+	 */
+	public function fix_headings( \DOMDocument &$dom, \DOMXPath &$xpath ) {
+
+		$headings = array( 'h3', 'h4', 'h5' );
+
+		foreach ( $headings as $heading_tag ) {
+			foreach ( $dom->getElementsByTagName( $heading_tag ) as $node ) {
+
+				$h2 = $dom->createElement( 'h2' );
+
+				while ( $node->childNodes->length > 0 ) {
+					$h2->appendChild( $node->childNodes->item(0) );
+				}
+
+				$node->parentNode->replaceChild( $h2, $node );
+
+			}
+		}
+
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -462,7 +462,7 @@ class Simple_FB_Instant_Articles {
 
 			while ( $headings->length ) {
 
-				$node = $headings->item( $i );
+				$node = $headings->item( 0 );
 				$h2   = $dom->createElement( 'h2' );
 
 				while ( $node->childNodes->length > 0 ) {


### PR DESCRIPTION
Reformat all headings to h2 to fix the warnings. Even though it doesn't actually matter.

See https://jira.gannett.com/secure/RapidBoard.jspa?rapidView=1220&view=detail&selectedIssue=LAW-298
