### PR TITLE
Fix images

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -214,11 +214,7 @@ class Simple_FB_Instant_Articles {
 		echo '<figure class="op-slideshow">';
 
 		foreach ( $ids as $id ) {
-
-			if ( $image = wp_get_attachment_image_src( $id, $this->image_size ) ) {
-				$this->render_image_markup( $image[0], $this->get_image_caption( $id ) );
-			}
-
+			$this->render_image_markup( $id, $this->get_image_caption( $id ) );
 		}
 
 		echo '</figure>';
@@ -242,9 +238,8 @@ class Simple_FB_Instant_Articles {
 
 		// Get attachment ID from the shortcode attribute.
 		$attachment_id = isset( $atts['id'] ) ? (int) str_replace( 'attachment_', '', $atts['id'] ) : null;
-		$image         = wp_get_attachment_image_src( $attachment_id, $this->image_size );
 
-		if ( ! $image ) {
+		if ( ! $attachment_id ) {
 			return;
 		}
 
@@ -253,7 +248,7 @@ class Simple_FB_Instant_Articles {
 		$caption = isset( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		ob_start();
-		$this->render_image_markup( $image[0], $caption );
+		$this->render_image_markup( $attachment_id, $caption );
 		return ob_get_clean();
 
 	}
@@ -265,6 +260,17 @@ class Simple_FB_Instant_Articles {
 	 * @param string $caption  Image caption to display in FB IA format.
 	 */
 	public function render_image_markup( $src, $caption = '' ) {
+
+		// Handle passing image ID.
+		if ( is_numeric( $src ) ) {
+			$image = wp_get_attachment_image_src( $src, $this->image_size );
+			$src   = $image ? $image[0] : null;
+		}
+
+		if ( empty( $src ) ) {
+			return;
+		}
+
 		$template = trailingslashit( $this->template_path ) . 'image.php';
 		require( $template );
 	}

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -212,11 +212,15 @@ class Simple_FB_Instant_Articles {
 		ob_start();
 
 		echo '<figure class="op-slideshow">';
+
 		foreach ( $ids as $id ) {
+
 			if ( $image = wp_get_attachment_image_src( $id, $this->image_size ) ) {
 				$this->render_image_markup( $image[0], $this->get_image_caption( $id ) );
 			}
+
 		}
+
 		echo '</figure>';
 
 		return ob_get_clean();
@@ -238,14 +242,14 @@ class Simple_FB_Instant_Articles {
 
 		// Get attachment ID from the shortcode attribute.
 		$attachment_id = isset( $atts['id'] ) ? (int) str_replace( 'attachment_', '', $atts['id'] ) : null;
-		$image = wp_get_attachment_image_src( $attachment_id, $this->image_size );
+		$image         = wp_get_attachment_image_src( $attachment_id, $this->image_size );
 
 		if ( ! $image ) {
 			return;
 		}
 
 		// Get image caption.
-		$reg_ex = preg_match( '#^<img.*?\/>(.*)$#', trim( $content ), $matches );
+		$reg_ex  = preg_match( '#^<img.*?\/>(.*)$#', trim( $content ), $matches );
 		$caption = isset( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		ob_start();
@@ -265,6 +269,13 @@ class Simple_FB_Instant_Articles {
 		require( $template );
 	}
 
+	/**
+	 * Get caption for image.
+	 *
+	 * @param  mixed $id attachment ID.
+	 *
+	 * @return string
+	 */
 	public function get_image_caption( $id ) {
 
 		$attachment_post = get_post( $id );

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -220,7 +220,6 @@ class Simple_FB_Instant_Articles {
 		echo '</figure>';
 
 		return ob_get_clean();
-
 	}
 
 	/**
@@ -250,14 +249,13 @@ class Simple_FB_Instant_Articles {
 		ob_start();
 		$this->render_image_markup( $attachment_id, $caption );
 		return ob_get_clean();
-
 	}
 
 	/**
 	 * Outputs image markup in FB IA format.
 	 *
-	 * @param int    $image_id Image ID to output in FB IA format.
-	 * @param string $caption  Image caption to display in FB IA format.
+	 * @param int|string $src     Image ID or source to output in FB IA format.
+	 * @param string     $caption Image caption to display in FB IA format.
 	 */
 	public function render_image_markup( $src, $caption = '' ) {
 
@@ -278,19 +276,17 @@ class Simple_FB_Instant_Articles {
 	/**
 	 * Get caption for image.
 	 *
-	 * @param  mixed $id attachment ID.
+	 * @param int $id Attachment/image ID.
 	 *
-	 * @return string
+	 * @return string Attachment/image caption, if specified.
 	 */
 	public function get_image_caption( $id ) {
 
 		$attachment_post = get_post( $id );
 
-		// Stop if - attachment post not found or caption is empty.
 		if ( $attachment_post && $attachment_post->post_excerpt ) {
 			return trim( $attachment_post->post_excerpt );
 		}
-
 	}
 
 	/**
@@ -329,7 +325,6 @@ class Simple_FB_Instant_Articles {
 		echo '</figure>';
 
 		return ob_get_clean();
-
 	}
 
 	/**
@@ -507,7 +502,6 @@ class Simple_FB_Instant_Articles {
 		ob_start();
 		require( $analytics_template_file );
 		return ob_get_clean();
-
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -213,7 +213,9 @@ class Simple_FB_Instant_Articles {
 
 		echo '<figure class="op-slideshow">';
 		foreach ( $ids as $id ) {
-			$this->render_image_markup( $id, $this->get_image_caption( $id ) );
+			if ( $image = wp_get_attachment_image_src( $id, $this->image_size ) ) {
+				$this->render_image_markup( $image[0], $this->get_image_caption( $id ) );
+			}
 		}
 		echo '</figure>';
 
@@ -235,9 +237,10 @@ class Simple_FB_Instant_Articles {
 	public function caption_shortcode( $atts, $content = '' ) {
 
 		// Get attachment ID from the shortcode attribute.
-		$attachment_id = isset( $atts['id'] ) ? (int) str_replace( 'attachment_', '', $atts['id'] ) : '';
+		$attachment_id = isset( $atts['id'] ) ? (int) str_replace( 'attachment_', '', $atts['id'] ) : null;
+		$image = wp_get_attachment_image_src( $attachment_id, $this->image_size );
 
-		if ( ! $attachment_id ) {
+		if ( ! $image ) {
 			return;
 		}
 
@@ -246,7 +249,7 @@ class Simple_FB_Instant_Articles {
 		$caption = isset( $matches[1] ) ? trim( $matches[1] ) : '';
 
 		ob_start();
-		$this->render_image_markup( $attachment_id, $caption );
+		$this->render_image_markup( $image[0], $caption );
 		return ob_get_clean();
 
 	}
@@ -257,19 +260,9 @@ class Simple_FB_Instant_Articles {
 	 * @param int    $image_id Image ID to output in FB IA format.
 	 * @param string $caption  Image caption to display in FB IA format.
 	 */
-	public function render_image_markup( $image_id, $caption = '' ) {
-
-		$image = wp_get_attachment_image_src( $image_id, $this->image_size );
-
-		if ( ! $image ) {
-			return;
-		}
-
+	public function render_image_markup( $src, $caption = '' ) {
 		$template = trailingslashit( $this->template_path ) . 'image.php';
-		$src      = $image[0] ;
-
 		require( $template );
-
 	}
 
 	public function get_image_caption( $id ) {
@@ -304,28 +297,22 @@ class Simple_FB_Instant_Articles {
 			return;
 		}
 
-		// Display API gallery in FB IA format.
 		ob_start();
-		?>
 
-		<figure class="op-slideshow">
+		echo '<figure class="op-slideshow">';
 
-			<?php
+		foreach ( $gallery->images as $key => $image ) {
+			$this->render_image_markup( $image->url, $image->custom_caption );
+		}
 
-			foreach ( $gallery->images as $key => $image ) {
-				$this->render_image_markup( $image->url, $image->custom_caption );
-			}
+		if ( $atts['title'] ) {
+			printf( '<figcaption><h1>%s</h1></figcaption>', esc_html( $atts['title'] ) );
+		}
 
-			?>
+		echo '</figure>';
 
-			<?php if ( $atts['title'] ) : ?>
-				<figcaption><h1><?php echo esc_html( $atts['title'] ); ?></h1></figcaption>
-			<?php endif;?>
-
-		</figure>
-
-		<?php
 		return ob_get_clean();
+
 	}
 
 	/**
@@ -539,8 +526,8 @@ class Simple_FB_Instant_Articles {
 	protected function get_ad_targeting_params() {
 
 		// Note use of get_the_terms + wp_list_pluck as these are cached ang get_the_* is not.
-		$tags    = wp_list_pluck( array_filter( (array) get_the_terms( get_the_ID(), 'post_tag' ) ), 'name' );
-		$cats    = wp_list_pluck( array_filter( (array) get_the_terms( get_the_ID(), 'category' ) ), 'name' );
+		$tags    = wp_list_pluck( (array) get_the_terms( get_the_ID(), 'post_tag' ), 'name' );
+		$cats    = wp_list_pluck( (array) get_the_terms( get_the_ID(), 'category' ), 'name' );
 		$authors = wp_list_pluck( get_coauthors( get_the_ID() ), 'display_name' );
 
 		$url_bits = parse_url( home_url() );

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -21,7 +21,7 @@ $plugin = Simple_FB_Instant_Articles::instance();
 	<?php
 
 	// Post featured image as FB IA cover image.
-	if ( has_post_thumbnail() && $image = wp_get_attachment_image_src( get_post_thumbnail_id(), $plugin->image_size ) ) {
+	if ( $image = wp_get_attachment_image_src( get_post_thumbnail_id(), $plugin->image_size ) ) {
 		$plugin->render_image_markup( $image[0] );
 	}
 

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -12,17 +12,14 @@
  *
  * @see https://developers.facebook.com/docs/instant-articles/guides/articlecreate#specify-cover
  */
-
 ?>
 <header>
 
 	<?php
-
 	// Post featured image as FB IA cover image.
 	if ( $thumb_id = get_post_thumbnail_id() ) {
 		Simple_FB_Instant_Articles::instance()->render_image_markup( $thumb_id );
 	}
-
 	?>
 
 	<?php the_title( '<h1>', '</h1>' ); ?>

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -19,8 +19,8 @@
 	<?php
 
 	// Post featured image as FB IA cover image.
-	if ( has_post_thumbnail() ) {
-		Simple_FB_Instant_Articles::instance()->render_image_markup( get_post_thumbnail_id() );
+	if ( $thumb_id = get_post_thumbnail_id() ) {
+		Simple_FB_Instant_Articles::instance()->render_image_markup( $thumb_id );
 	}
 
 	?>

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -21,8 +21,8 @@ $plugin = Simple_FB_Instant_Articles::instance();
 	<?php
 
 	// Post featured image as FB IA cover image.
-	if ( $image = wp_get_attachment_image_src( get_post_thumbnail_id(), $plugin->image_size ) ) {
-		$plugin->render_image_markup( $image[0] );
+	if ( has_post_thumbnail() ) {
+		$plugin->render_image_markup( get_post_thumbnail_id() );
 	}
 
 	?>

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -12,14 +12,17 @@
  *
  * @see https://developers.facebook.com/docs/instant-articles/guides/articlecreate#specify-cover
  */
+
+$plugin = Simple_FB_Instant_Articles::instance();
+
 ?>
 <header>
 
 	<?php
 
 	// Post featured image as FB IA cover image.
-	if ( $thumb_id = get_post_thumbnail_id() ) {
-		Simple_FB_Instant_Articles::instance()->render_image_markup( $thumb_id );
+	if ( has_post_thumbnail() && $image = wp_get_attachment_image_src( get_post_thumbnail_id(), $plugin->image_size ) ) {
+		$plugin->render_image_markup( $image[0] );
 	}
 
 	?>

--- a/templates/article-cover.php
+++ b/templates/article-cover.php
@@ -13,8 +13,6 @@
  * @see https://developers.facebook.com/docs/instant-articles/guides/articlecreate#specify-cover
  */
 
-$plugin = Simple_FB_Instant_Articles::instance();
-
 ?>
 <header>
 
@@ -22,7 +20,7 @@ $plugin = Simple_FB_Instant_Articles::instance();
 
 	// Post featured image as FB IA cover image.
 	if ( has_post_thumbnail() ) {
-		$plugin->render_image_markup( get_post_thumbnail_id() );
+		Simple_FB_Instant_Articles::instance()->render_image_markup( get_post_thumbnail_id() );
 	}
 
 	?>


### PR DESCRIPTION
Oops. In my haste writing the `render_image_markup` method, I was passing both `image_id` and `src` as the first param. Obviously only one works.

I think this method should be consistent and do 1 thing. Render the template given the src and caption. 
