### PR TITLE
no need to filter this array.

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -539,8 +539,8 @@ class Simple_FB_Instant_Articles {
 	protected function get_ad_targeting_params() {
 
 		// Note use of get_the_terms + wp_list_pluck as these are cached ang get_the_* is not.
-		$tags    = wp_list_pluck( array_filter( (array) get_the_terms( get_the_ID(), 'post_tag' ) ), 'name' );
-		$cats    = wp_list_pluck( array_filter( (array) get_the_terms( get_the_ID(), 'category' ) ), 'name' );
+		$tags    = wp_list_pluck( (array) get_the_terms( get_the_ID(), 'post_tag' ), 'name' );
+		$cats    = wp_list_pluck( (array) get_the_terms( get_the_ID(), 'category' ), 'name' );
 		$authors = wp_list_pluck( get_coauthors( get_the_ID() ), 'display_name' );
 
 		$url_bits = parse_url( home_url() );


### PR DESCRIPTION
Thought I'd pushed this commit to https://github.com/humanmade/Simple-Instant-Articles-for-Facebook/pull/37/files

We don't need to filter the array. This was added to strip empty array items that you sometimes get casting to an array. But get the terms will return `array()` or `false`. And `(array) false` gives you `array()`. No need to filter.

Got confused with casting `null` to an array. This to an array gives `array( 0 => false );` because ¯_(ツ)_/¯
