### PR TITLE
don't double quote profile ID

### DIFF
--- a/templates/script-ga.php
+++ b/templates/script-ga.php
@@ -6,7 +6,7 @@
 			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-			ga('create', '<?php echo wp_json_encode( $ga_profile_id ); ?>', 'auto');
+			ga('create', <?php echo wp_json_encode( $ga_profile_id ); ?>, 'auto');
 			ga('send', 'pageview');
 		</script>
 	</iframe>


### PR DESCRIPTION
VIP requested we switch to `wp_json_encode` from `esc_js`. Got caught out by the fact that json encode wraps in quotes and esc_js doesn't. This broke the GA script.
