### PR TITLE
LAW-303 Fix protected iframes

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -166,6 +166,9 @@ class Simple_FB_Instant_Articles {
 		add_shortcode( 'gallery', array( $this, 'gallery_shortcode' ) );
 		add_shortcode( 'caption', array( $this, 'caption_shortcode' ) );
 
+		// Try and fix misc shortcodes.
+		$this->make_shortcode_figure_op_social( 'protected-iframe' );
+
 		// Shortcodes - custom galleries.
 		add_shortcode( 'sigallery', array( $this, 'api_galleries_shortcode' ) );
 
@@ -565,6 +568,34 @@ class Simple_FB_Instant_Articles {
 		foreach ( $this->get_ad_targeting_params() as $key => $value ) {
 			printf( ".setTargeting( '%s', %s )", esc_js( $key ), wp_json_encode( $value ) );
 		}
+	}
+
+	/**
+	 * Wrap shortcode output in figure op-social + iframe markup to sandbox functionality.
+	 *
+	 * Used to handle generic shortcodes that we don't really want to mess with might be broken.
+	 *
+	 * @param  string $shortcode_tag Shortcode.
+	 * @return void
+	 */
+	protected function make_shortcode_figure_op_social( $shortcode_tag ) {
+
+		global $shortcode_tags;
+
+		if ( ! isset( $shortcode_tags[ $shortcode_tag ] ) ) {
+			return;
+		}
+
+		$old_callback = $shortcode_tags[ $shortcode_tag ];
+
+		$shortcode_tags['protected-iframe'] = function() use ( $old_callback ) {
+
+			$r = '<figure class="op-social"><iframe>';
+			$r .= call_user_func_array( $old_callback, func_get_args() );
+			$r .= '</iframe></figure>';
+			return $r;
+		};
+
 	}
 
 	/**


### PR DESCRIPTION
https://jira.gannett.com/secure/RapidBoard.jspa?rapidView=1220&view=detail&selectedIssue=LAW-303

Pretty neat feature on WordPress.com VIP, you can embed content from untrusted sources using their embed tool. Basically it allows you to dump any old embed code - whatever it may be, from wherever. This is then rendered inside an iFrame to sandbox it from the rest of your site.

Technically I think its storing the insecure embed code elsewhere (post type? maybe off-site?) and then using the `protected-iframe` shortcode to render it. 

This is actually very similar to how Facebook is dealing with embeds from us inside Instant Articles.

**The problem.**

The `protected-iframe` shortcode outputs a bunch of code - script, form and iframe, that is obviously not trusted by FB. We need to wrap this in their secure embed markup `<figure class="op-social"><iframe>// Code </iframe></figure>`

For reference the `protected-iframe` shortcode outputs something similar to the code below. 

``` html
<form action="/* somewhere on //wpcomwidgets.com/  */" target="unique-id"> 
    /* inputs containing all args that need to be passed to iframe. */ 
</form>
<iframe id="unique-id"></iframe>
<script>
    // trigger form submit, that then displays form response in iframe
</script>
```

**The next problem.**

We either need to remove this, or get it to work inside a FB embed.  But its a bit of a black box as I can't run this locally to test. 

**My Solution**

Our current approach to shortcodes is to replace the output with custom markup. But as we don't we have access to the source code for protected-iframes, I think this is out of the question here.

For oEmbeds we're just adding the `<figure><iframe>` markup before and after using actions.

My fix is to hack the shortcode callback. I replace the `protected-iframe` callback with a custom one. This then outputs the markup required, and calls the original shortcode callback inside it.

I don't know if this is crazy, whether it will work, and whether there is a better solution. Would be good to get some feedback!
