### PR TITLE
Fix encoding issues

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -368,11 +368,17 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function reformat_post_content( $post_content ) {
 
-		$dom = new \DOMDocument();
+		$dom = new \DomDocument();
 
 		// Parse post content to generate DOM document.
 		// Use loadHTML as it doesn't need to be well-formed to load.
-		@$dom->loadHTML( '<html><body>' . $post_content . '</body></html>' );
+		// Charset meta tag required to ensure it correctly detects the encoding.
+		@$dom->loadHTML( sprintf(
+			'<html><head><meta http-equiv="Content-Type" content="%s" charset="%s"/></head><body>%s</body></html>',
+			get_bloginfo( 'html_type' ),
+			get_bloginfo( 'charset' ),
+			$post_content
+		) );
 
 		// Stop - if dom isn't generated.
 		if ( ! $dom ) {


### PR DESCRIPTION
https://jira.gannett.com/secure/RapidBoard.jspa?rapidView=1220&view=detail&selectedIssue=LAW-309

DomDocument is not good at detecting encoding, and will assume LATIN1. We probably want UTF-8. Adding a charset meta tag to the header just like you would on the front end fixes the problem.
