### PR TITLE
Ensure scripts are loaded for brightcove oembed

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -225,14 +225,15 @@ class Simple_FB_Instant_Articles {
 		add_filter( 'embed_handler_html', array( $this, 'reformat_social_embed' ), 10, 3 );
 		add_filter( 'embed_oembed_html', array( $this, 'reformat_social_embed' ), 10, 4 );
 
+		// Fix embeds that need some extra attention.
+		add_filter( 'embed_handler_html', array( $this, 'load_brightcove_scripts' ), 5, 2 );
+
 		// Modify the content.
 		add_filter( 'the_content', array( $this, 'reformat_post_content' ), 1000 );
 		add_action( 'the_content', array( $this, 'append_google_analytics_code' ), 1100 );
 		add_action( 'the_content', array( $this, 'append_ad_code' ), 1100 );
 		add_action( 'the_content', array( $this, 'append_omniture_code' ), 1100 );
 		add_action( 'the_content', array( $this, 'prepend_full_width_media' ), 1100 );
-
-		add_filter( 'simple_fb_social_embed_html', array( $this, 'load_brightcove_scripts' ), 10, 4 );
 
 		// Post URL for the feed.
 		add_filter( 'the_permalink_rss', array( $this, 'rss_permalink' ) );
@@ -404,10 +405,7 @@ class Simple_FB_Instant_Articles {
 	 * @return string           FB IA formatted markup for social embeds.
 	 */
 	public function reformat_social_embed( $html, $url, $attr, $post_ID = null ) {
-
-		$html = apply_filters( 'simple_fb_social_embed_html', $html, $url, $attr, $post_ID );
 		return sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
-
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -232,6 +232,8 @@ class Simple_FB_Instant_Articles {
 		add_action( 'the_content', array( $this, 'append_omniture_code' ), 1100 );
 		add_action( 'the_content', array( $this, 'prepend_full_width_media' ), 1100 );
 
+		add_filter( 'simple_fb_social_embed_html', array( $this, 'load_brightcove_scripts' ), 10, 4 );
+
 		// Post URL for the feed.
 		add_filter( 'the_permalink_rss', array( $this, 'rss_permalink' ) );
 
@@ -403,7 +405,30 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function reformat_social_embed( $html, $url, $attr, $post_ID = null ) {
 
-		return '<figure class="op-social"><iframe>' . $html . '</iframe></figure>';
+		$html = apply_filters( 'simple_fb_social_embed_html', $html, $url, $attr, $post_ID );
+		return sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
+
+	}
+
+	/**
+	 * Ensure brightcove scripts are loaded.
+	 *
+	 * @param  string $html Embed markup.
+	 * @param  string $url  Embed url.
+	 *
+	 * @return string Embed markup.
+	 */
+	function load_brightcove_scripts( $html, $url ) {
+
+		if ( preg_match( '#(http|https)://link.brightcove\.com/services/player/bcpid(.*)\?(.*)#i', $url ) ) {
+			ob_start();
+			do_action( 'wp_enqueue_scripts' );
+			wp_print_scripts( 'brightcove' );
+			$html .= ob_get_clean();
+		}
+
+		return $html;
+
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -221,12 +221,12 @@ class Simple_FB_Instant_Articles {
 		add_shortcode( 'lawrence-related', '__return_empty_string' );
 		add_shortcode( 'lawrence-auto-related', '__return_empty_string' );
 
+		// Fix embeds that need some extra attention.
+		add_filter( 'embed_handler_html', array( $this, 'load_brightcove_scripts' ), 5, 2 );
+
 		// Render social embeds into FB IA format.
 		add_filter( 'embed_handler_html', array( $this, 'reformat_social_embed' ), 10, 3 );
 		add_filter( 'embed_oembed_html', array( $this, 'reformat_social_embed' ), 10, 4 );
-
-		// Fix embeds that need some extra attention.
-		add_filter( 'embed_handler_html', array( $this, 'load_brightcove_scripts' ), 5, 2 );
 
 		// Modify the content.
 		add_filter( 'the_content', array( $this, 'reformat_post_content' ), 1000 );
@@ -405,6 +405,7 @@ class Simple_FB_Instant_Articles {
 	 * @return string           FB IA formatted markup for social embeds.
 	 */
 	public function reformat_social_embed( $html, $url, $attr, $post_ID = null ) {
+
 		return sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
 	}
 
@@ -417,7 +418,6 @@ class Simple_FB_Instant_Articles {
 	 * @return string Embed markup.
 	 */
 	function load_brightcove_scripts( $html, $url ) {
-
 		global $wp_embed;
 
 		$brightcove_handler = null;
@@ -441,7 +441,6 @@ class Simple_FB_Instant_Articles {
 		}
 
 		return $html;
-
 	}
 
 	/**


### PR DESCRIPTION
The Brightcove embed handler enqueues a script. We need to make sure this is output inside the FB social iframe.

I'm trying to avoid just hardcoding the script into our facebook stuff - but was a bit tricky! Have to find the embed handler and check the regex against it, then hack the script to load. Might be over complicating this.
