### PR TITLE
Remove meta query. Skip hidden/sponsored in feed

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -177,38 +177,6 @@ class Simple_FB_Instant_Articles {
 			$num_posts = intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) );
 			$query->set( 'posts_per_rss', $num_posts );
 
-			// Meta query to exclude:
-			// 1) sponsored posts.
-			// 2) posts marked to be excluded from the feed.
-			$query->set( 'meta_query', array(
-				'relation' => 'AND',
-				array(
-					'relation' => 'OR',
-					array(
-						'key'     => '_format_sponsored_link',
-						'value'   => '',
-						'compare' => '=',
-					),
-					array(
-						'key'     => '_format_sponsored_link',
-						'compare' => 'NOT EXISTS',
-					),
-				),
-				array(
-					'relation' => 'OR',
-					array(
-						'key'     => '_lawrence_hide_on_fb_ia_feed',
-						'value'   => 0,
-						'compare' => '=',
-						'type'    => 'NUMERIC',
-					),
-					array(
-						'key'     => '_lawrence_hide_on_fb_ia_feed',
-						'compare' => 'NOT EXISTS',
-					),
-				),
-			) );
-
 			do_action( 'simple_fb_pre_get_posts', $query );
 		}
 	}
@@ -446,8 +414,8 @@ class Simple_FB_Instant_Articles {
 
 		// If the embed is any kind of facebook embed, try and load the Facebook SDK.
 		// Can't use precise regex, as we don't really know what WP.com is doing here!
-		if ( false !== strpos( $url, 'facebook.com' ) ) {
-
+		// Check this hasn't been added already.
+		if ( false !== strpos( $url, 'facebook.com' ) && false === strpos( $html, 'connect.facebook.net' ) ) {
 			$html .= '<div id="fb-root"></div> <script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = "//connect.facebook.net/en_US/all.js#xfbml=1"; fjs.parentNode.insertBefore(js, fjs); }(document, "script", "facebook-jssdk"));</script>';
 		}
 

--- a/templates/feed.php
+++ b/templates/feed.php
@@ -39,6 +39,21 @@ echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) )
 
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : the_post(); ?>
+
+			<?php
+
+			// Skip if sponsored.
+			if ( class_exists( '\USAT\Sponsored_Posts' ) && \USAT\Sponsored_Posts::instance()->is_sponsored() )  {
+				continue;
+			}
+
+			// Skip if hidden from feed.
+			if ( (bool) get_post_meta( get_the_ID(), '_lawrence_hide_on_fb_ia_feed', true ) ) {
+				continue;
+			}
+
+			?>
+
 			<item>
 				<title><?php esc_html( the_title_rss() ); ?></title>
 				<link><?php the_permalink_rss(); ?></link>


### PR DESCRIPTION
This meta query doesn't scale. Even before adding the bit for  `_lawrence_hide_on_fb_ia_feed`, the feed was taking a long time to generate. 10+ seconds. Too long for Facebook and they are reporting errors. (Not a total deal breaker, they will retry after 3 minutes and since we cache for 5 - this works OK)

Quick solution - just skip these posts in the loop. Should be fine because there won't be too many, and FB will probably handle having fewer than 10 posts in the feed no problem.

Longer term solution - we need to do better querying. 
- We could try a tax query, but multiple taxonomy queries can be pretty slow too.
- Store IDs to be hidden as option, update this on save post, and pass as `post_not__in`? But will this scale for sponsored?
