### PR TITLE
Orderby last modified. Remove filter for posts_per_page

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -174,8 +174,8 @@ class Simple_FB_Instant_Articles {
 		// Customise FB IA feed query.
 		if ( $query->is_main_query() && $query->is_feed( $feed_slug ) ) {
 
-			$num_posts = intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) );
-			$query->set( 'posts_per_rss', $num_posts );
+			$query->set( 'posts_per_rss', 25 );
+			$query->set( 'orderby', 'modified' );
 
 			do_action( 'simple_fb_pre_get_posts', $query );
 		}


### PR DESCRIPTION
To make sure updated posts find their way back into facebook, order by last modified date instead of publish date.

Also remove filter for posts per page. We don't need this.
