### PR TITLE
Try and fix youtube

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -438,7 +438,9 @@ class Simple_FB_Instant_Articles {
 		// If the op-social embed iframe is the only child and direct decendant of another iframe, unwrap.
 		foreach ( $xpath->query( '//figure[contains(@class, \'op-social\')]/iframe/iframe' ) as $node ) {
 			if ( $node->parentNode->childNodes->length === 1 ) {
+				$parent = $node->parentNode;
 				$node->parentNode->parentNode->insertBefore( $node, $node->parentNode );
+				$parent->parentNode->removeChild( $parent );
 			}
 		}
 

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -400,7 +400,6 @@ class Simple_FB_Instant_Articles {
 		}
 
 		return sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
-
 	}
 
 	/**
@@ -419,10 +418,13 @@ class Simple_FB_Instant_Articles {
 
 		foreach ( $items as $node ) {
 
+			// Remove empty <span> and <div> nodes.
 			if ( ! $node->hasChildNodes() ) {
 				$node->parentNode->removeChild( $node );
 			}
 
+			// Insert inner content of <span> and <div> nodes just before themselves,
+			// So they are siblings (on the same level).
 			while ( $node->childNodes->length > 0 ) {
 				$node->parentNode->insertBefore(
 					$node->childNodes->item( $node->childNodes->length - 1 ),
@@ -430,6 +432,7 @@ class Simple_FB_Instant_Articles {
 				);
 			}
 
+			// Remove original <span> and <div> elements.
 			$node->parentNode->removeChild( $node );
 		}
 

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -231,7 +231,6 @@ class Simple_FB_Instant_Articles {
 		add_action( 'simple_fb_reformat_post_content', array( $this, 'cleanup_empty_p' ), 10, 2 );
 		add_action( 'simple_fb_reformat_post_content', array( $this, 'fix_headings' ), 10, 2 );
 		add_action( 'simple_fb_reformat_post_content', array( $this, 'fix_social_embed' ), 1000, 2 );
-
 	}
 
 	public function rss_permalink( $link ) {
@@ -432,18 +431,21 @@ class Simple_FB_Instant_Articles {
 			}
 
 			$node->parentNode->removeChild( $node );
-
 		}
 
-		// If the op-social embed iframe is the only child and direct decendant of another iframe, unwrap.
+		// If the op-social embed iframe is the only child of another iframe, unwrap.
 		foreach ( $xpath->query( '//figure[contains(@class, \'op-social\')]/iframe/iframe' ) as $node ) {
-			if ( $node->parentNode->childNodes->length === 1 ) {
-				$parent = $node->parentNode;
+			if ( 1 === $node->parentNode->childNodes->length ) {
+
+				$outer_iframe = $node->parentNode;
+
+				// Insert inner <iframe> before outer <iframe> element - so they are both children of <figure>.
 				$node->parentNode->parentNode->insertBefore( $node, $node->parentNode );
-				$parent->parentNode->removeChild( $parent );
+
+				// Remove outer <iframe>.
+				$outer_iframe->parentNode->removeChild( $outer_iframe );
 			}
 		}
-
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -401,6 +401,9 @@ class Simple_FB_Instant_Articles {
 		}
 
 		return sprintf( '<figure class="op-social"><iframe>%s</iframe></figure>', $html );
+
+	}
+
 	/**
 	 * Some markup fixes for embeds.
 	 *

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -412,7 +412,7 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function fix_social_embed( \DOMDocument $dom, \DOMXPath $xpath ) {
 
-		// Matches all divs and spans that have class like ~=embed- and are children of figure.
+		// Matches all divs and spans that have class like ~=embed- and are descendants of figure.
 		// Unwrap, or remove if no children.
 		$items = $xpath->query( '//figure[contains(@class, \'op-social\')]//*[self::span or self::div][contains(@class, \'embed-\')]' );
 


### PR DESCRIPTION
FB doesn't seem to like our markup. There are a few differences I've noticed from ours, the documentation, and other feeds
1. Our embeds are wrapped in a div or span with the class like `embed-`. We can fairly easily unwrap these using.
2. We're left with something like the following. `<iframe><iframe src="">`. I don't think this is 100% necessary,  and the video will render full width if we can strip the outer iframe. However we can only do this if the embed uses an iframe, and not if using scripts and other markup, so I'm quite strict about checking this is the only element.
