### PR TITLE
Cleanup empty `<a>` elements

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -542,7 +542,7 @@ class Simple_FB_Instant_Articles {
 
 			// If image node is not a direct child of the body, we need to move it there.
 			// Recurse up the tree looking for highest level parent/grandparent node.
-			while ( $top_node->parentNode && 'body' !== $top_node->parentNode->tagName ) {
+			while ( $top_node->parentNode && 'body' !== $top_node->parentNode->nodeName ) {
 				$top_node = $top_node->parentNode;
 			}
 

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -575,12 +575,15 @@ class Simple_FB_Instant_Articles {
 		foreach ( $target_tags as $target_tag ) {
 
 			$list  = $xpath->query( '//' . $target_tag . '[not(node())]' );
-			$found = $found || (bool) $list->length;
+			$found = (bool) $list->length;
+
+			if ( ! $found ) {
+				return;
+			}
 
 			foreach ( $list as $node ) {
 				$node->parentNode->removeChild( $node );
 			}
-
 		}
 
 		// If we found anything, run this again.
@@ -588,7 +591,6 @@ class Simple_FB_Instant_Articles {
 		if ( $found ) {
 			$this->cleanup_empty_nodes( $dom, $xpath );
 		}
-
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -560,7 +560,7 @@ class Simple_FB_Instant_Articles {
 	}
 
 	/**
-	 * Remove all empty elements.
+	 * Remove empty elements from list of tag names.
 	 *
 	 * @param  \DOMDocument &$dom   DOM object generated for post content.
 	 * @param  \DOMXPath    &$xpath XPATH object generated for post content.

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -595,11 +595,15 @@ class Simple_FB_Instant_Articles {
 	public function cleanup_empty_nodes( \DOMDocument &$dom, \DOMXPath &$xpath ) {
 
 		$target_tags = array( 'p', 'a' );
-		$found       = false;
+
+		// Keep track of whether any empty nodes have been found.
+		$found = false;
 
 		foreach ( $target_tags as $target_tag ) {
 
 			$list  = $xpath->query( '//' . $target_tag . '[not(node())]' );
+
+			// Update found. But don't set back to false.
 			$found = $found || (bool) $list->length;
 
 			foreach ( $list as $node ) {

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -600,15 +600,12 @@ class Simple_FB_Instant_Articles {
 		foreach ( $target_tags as $target_tag ) {
 
 			$list  = $xpath->query( '//' . $target_tag . '[not(node())]' );
-			$found = (bool) $list->length;
-
-			if ( ! $found ) {
-				return;
-			}
+			$found = $found || (bool) $list->length;
 
 			foreach ( $list as $node ) {
 				$node->parentNode->removeChild( $node );
 			}
+
 		}
 
 		// If we found anything, run this again.
@@ -616,6 +613,7 @@ class Simple_FB_Instant_Articles {
 		if ( $found ) {
 			$this->cleanup_empty_nodes( $dom, $xpath );
 		}
+
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -555,7 +555,6 @@ class Simple_FB_Instant_Articles {
 			}
 
 			$figure->appendChild( $node );
-
 		}
 	}
 

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -567,7 +567,7 @@ class Simple_FB_Instant_Articles {
 	 *
 	 * @return void
 	 */
-	public function cleanup_empty_p( \DOMDocument &$dom, \DOMXPath &$xpath ) {
+	public function cleanup_empty_nodes( \DOMDocument &$dom, \DOMXPath &$xpath ) {
 
 		$target_tags = array( 'p', 'a' );
 		$found       = false;


### PR DESCRIPTION
We're already stripping empty `<p>` tags so small extra step to loop through a list of tag names.
