### PR TITLE
Fix brightcove embeds

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -452,6 +452,30 @@ class Simple_FB_Instant_Articles {
 
 			$this->unwrap_node( $iframe->parentNode );
 		}
+
+		// Remove P and <br> tags from brightcove embed.
+		foreach ( $xpath->query( '//div[contains(@class, \'brightcove-embed\')]' ) as $node ) {
+
+			$br_nodes = $brightcove->parentNode->getElementsByTagName( 'br' );
+			$p_nodes  = $brightcove->parentNode->getElementsByTagName( 'p' );
+
+			while ( $br_nodes->length > 0 ) {
+				$br_nodes->item( 0 )->parentNode->removeChild( $br_nodes->item( 0 ) );
+			}
+
+			while ( $p_nodes->length > 0 ) {
+				$this->unwrap_node( $p_nodes->item(0) );
+			}
+
+		}
+
+		// Remove brightcove width/height params.
+		foreach ( $xpath->query( '//div[contains(@class, \'brightcove-embed\')]//param[@name="width" or @name="height"]' ) as $node ) {
+			if ( $node->parentNode ) {
+				$node->parentNode->removeChild( $node );
+			}
+		}
+
 	}
 
 	/**
@@ -490,7 +514,13 @@ class Simple_FB_Instant_Articles {
 		ob_start();
 		do_action( 'wp_enqueue_scripts' );
 		wp_print_scripts( 'brightcove' );
+
 		$embed .= ob_get_clean();
+
+		$embed .= '<style>';
+		$embed .= '.brightcove-embed { position: relative; padding-bottom: 56.25%; /* 16/9 ratio */ height: 0; overflow: hidden; }';
+		$embed .= '.brightcove-embed object { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }';
+		$embed .= '</style>';
 
 		return $embed;
 	}

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -454,7 +454,7 @@ class Simple_FB_Instant_Articles {
 		}
 
 		// Remove P and <br> tags from brightcove embed.
-		foreach ( $xpath->query( '//div[contains(@class, \'brightcove-embed\')]' ) as $node ) {
+		foreach ( $xpath->query( '//div[contains(@class, \'brightcove-embed\')]' ) as $brightcove ) {
 
 			$br_nodes = $brightcove->parentNode->getElementsByTagName( 'br' );
 			$p_nodes  = $brightcove->parentNode->getElementsByTagName( 'p' );


### PR DESCRIPTION
The advice from brightcove to make their embeds responsive is to add some CSS.

Also... there are some `<br>` and `<p>` tags that are messing up FB styling. I can just strip - they're getting added by wp_auto_p... which I'd rather not mess with.

Finally... despite this working on the real site, FB doesn't seem to like specifying the width/height of the embed. All works fine if I remove this.
