### PR TITLE
Fix missing brightcove script

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -509,7 +509,6 @@ class Simple_FB_Instant_Articles {
 	 * @return string Embed markup.
 	 */
 	public function load_brightcove_scripts( $embed, $matches, $attr, $url ) {
-
 		global $wp_scripts;
 
 		// Ensure scripts are registered.

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -510,11 +510,20 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function load_brightcove_scripts( $embed, $matches, $attr, $url ) {
 
-		ob_start();
-		do_action( 'wp_enqueue_scripts' );
-		wp_print_scripts( 'brightcove' );
+		global $wp_scripts;
 
-		$embed .= ob_get_clean();
+		// Ensure scripts are registered.
+		if ( ! did_action( 'wp_enqueue_scripts' ) ) {
+			do_action( 'wp_enqueue_scripts' );
+		}
+
+		// Check brightcove scripts are registered.
+		if ( ! wp_script_is( 'brightcove', 'registered' ) ) {
+			return $embed;
+		}
+
+		// Manually build script. Ensures always loaded, including multiple times.
+		$embed .= sprintf( '<script src="%s"></script>', $wp_scripts->registered['brightcove']->src );
 
 		$embed .= '<style>';
 		$embed .= '.brightcove-embed { position: relative; padding-bottom: 56.25%; /* 16/9 ratio */ height: 0; overflow: hidden; }';


### PR DESCRIPTION
Calling print scripts is too clever and prevents it getting loaded multiple times on a page. But we need this to happen every time. I think its uneccessary to hack the dependency system, and just output the script manually
