### PR TITLE
Strip tags from image caption

### DIFF
--- a/templates/image.php
+++ b/templates/image.php
@@ -4,7 +4,7 @@
 
 	<?php if ( ! empty( $caption ) ) : ?>
 		<figcaption>
-			<h1><?php echo esc_html( $caption ); ?></h1>
+			<h1><?php echo esc_html( strip_tags( $caption ) ); ?></h1>
 		</figcaption>
 	<?php endif; ?>
 


### PR DESCRIPTION
Otherwise HTML tags get escaped and don't show up in FB IA.
