### PR TITLE
Fix vine embed not matching regex

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -437,7 +437,7 @@ class Simple_FB_Instant_Articles {
 			'facebook\.com',
 			'twitter\.com',
 			'instagr(\.am|am\.com)',
-			'vine\.com',
+			'vine\.co',
 		) );
 
 		if ( preg_match( "/$regex_bits/", $url ) ) {


### PR DESCRIPTION
Vine embeds should be `op-social` and they're not because the embeds are using the `vine.co` domain.
